### PR TITLE
Add target branch to trigger/pipeline variables

### DIFF
--- a/gitlab-ci-build-on-merge-request.go
+++ b/gitlab-ci-build-on-merge-request.go
@@ -16,6 +16,7 @@ type requestBody struct {
 		Name string `json:"name"`
 	} `json:"project"`
 	ObjectAttributes struct {
+		TargetBranch    string `json:"target_branch"`
 		SourceBranch    string `json:"source_branch"`
 		SourceProjectId int    `json:"source_project_id"`
 		State           string `json:"state"` // merged, opened or closed
@@ -132,11 +133,12 @@ func main() {
 			return
 		}
 		triggerUrl := fmt.Sprintf(
-			"%s/api/v4/projects/%d/trigger/pipeline?ref=%s&token=%s",
+			"%s/api/v4/projects/%d/trigger/pipeline?ref=%s&token=%s&variables[TARGET_BRANCH]=%s",
 			*baseURL,
 			requestBody.ObjectAttributes.SourceProjectId,
 			requestBody.ObjectAttributes.SourceBranch,
-			trigger.Token)
+			trigger.Token,
+			requestBody.ObjectAttributes.TargetBranch)
 		triggerRes, err := http.PostForm(triggerUrl, url.Values{})
 		if err != nil {
 			log.Printf("WARN: %s", err.Error())


### PR DESCRIPTION
Parses `target_branch` and sends it to CI via `TARGET_BRANCH` variable.

For us it was required to get the target branch to be able to locally merge source branch with target branch properly before the build. We build result of a merge to avoid a bit of extra testing, not only the branch itself.