### PR TITLE
Allow to not check SSL certificate

### DIFF
--- a/gitlab-ci-build-on-merge-request.go
+++ b/gitlab-ci-build-on-merge-request.go
@@ -60,7 +60,7 @@ func main() {
 	var baseURL = flag.String("url", "", "URL (e.g. http://gitlab.com)")
 	var privateTokenGlobal = flag.String("private_token", "", "Authorization Token (e.g. XXxXXx0xxxXXXxXxXxxX)")
 	var port = flag.Int("port", 8080, "Port")
-	var checkSSL = flag.Bool("check-ssl", true, "Check SSL certificate")
+	var noCheckSSL = flag.Bool("no-check-ssl", false, "Disable SSL certificate check")
 	flag.Parse()
 	if *baseURL == "" {
 		printUsageAndExit("Error: --url is required")
@@ -69,7 +69,7 @@ func main() {
 		printWarning("Warning: --private_token is not set")
 	}
 	// disable SSL certificate if requested
-	if !(*checkSSL) {
+	if *noCheckSSL {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	http.HandleFunc("/hook", func(w http.ResponseWriter, r *http.Request) {

--- a/gitlab-ci-build-on-merge-request.go
+++ b/gitlab-ci-build-on-merge-request.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"crypto/tls"
 )
 
 type requestBody struct {
@@ -59,12 +60,17 @@ func main() {
 	var baseURL = flag.String("url", "", "URL (e.g. http://gitlab.com)")
 	var privateTokenGlobal = flag.String("private_token", "", "Authorization Token (e.g. XXxXXx0xxxXXXxXxXxxX)")
 	var port = flag.Int("port", 8080, "Port")
+	var checkSSL = flag.Bool("check-ssl", true, "Check SSL certificate")
 	flag.Parse()
 	if *baseURL == "" {
 		printUsageAndExit("Error: --url is required")
 	}
 	if *privateTokenGlobal == "" {
 		printWarning("Warning: --private_token is not set")
+	}
+	// disable SSL certificate if requested
+	if !(*checkSSL) {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	http.HandleFunc("/hook", func(w http.ResponseWriter, r *http.Request) {
 		queryPrivateToken := r.URL.Query().Get("private_token")

--- a/gitlab-ci-build-on-merge-request.go
+++ b/gitlab-ci-build-on-merge-request.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -8,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"crypto/tls"
 )
 
 type requestBody struct {
@@ -60,7 +60,7 @@ func main() {
 	var baseURL = flag.String("url", "", "URL (e.g. http://gitlab.com)")
 	var privateTokenGlobal = flag.String("private_token", "", "Authorization Token (e.g. XXxXXx0xxxXXXxXxXxxX)")
 	var port = flag.Int("port", 8080, "Port")
-	var noCheckSSL = flag.Bool("no-check-ssl", false, "Disable SSL certificate check")
+	var insecure = flag.Bool("insecure", false, "Disable SSL certificate check")
 	flag.Parse()
 	if *baseURL == "" {
 		printUsageAndExit("Error: --url is required")
@@ -69,7 +69,7 @@ func main() {
 		printWarning("Warning: --private_token is not set")
 	}
 	// disable SSL certificate if requested
-	if *noCheckSSL {
+	if *insecure {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	http.HandleFunc("/hook", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This PR aims to fix #6.

It adds a flag `--no-ssl-check` that disables SSL certificate checks when communicating with the Gitlab instance. It hence allows this web hook to work with a Gitlab instance that uses a self-signed certificate.